### PR TITLE
fix: Exclude sazanami2 from THIRD-PARTY-LICENSES.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ serve:
 
 init:
 	npm install
-	npx license-checker --production --relativeLicensePath > THIRD-PARTY-LICENSES.md
+	npx license-checker --production --relativeLicensePath --excludePackages sazanami2@0.0.2 > THIRD-PARTY-LICENSES.md
 	sed -i "s|$(shell pwd)/||g" THIRD-PARTY-LICENSES.md
 
 clean:

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -190,11 +190,6 @@
 │  ├─ repository: https://github.com/facebook/react
 │  ├─ path: node_modules/react
 │  └─ licenseFile: node_modules/react/LICENSE
-├─ sazanami2@0.0.1
-│  ├─ licenses: BSD-3-Clause
-│  ├─ publisher: Ryota Shioya
-│  ├─ path: /home/shioya/work/sazanami2
-│  └─ licenseFile: LICENSE.md
 ├─ scheduler@0.23.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/react


### PR DESCRIPTION
sazanami2 is obviously not a "third-party", and including it also hurts reproducibility because the associated path is emitted as absolute.