### PR TITLE
feat: allow horizontal scroll with mouse wheel

### DIFF
--- a/src/main_canvas.tsx
+++ b/src/main_canvas.tsx
@@ -325,13 +325,20 @@ const MainCanvas: React.FC<{ store: Store }> = ({ store }) => {
             const mouseX = e.clientX - rect.left;
             const mouseY = e.clientY - rect.top;
 
+            // 一回の操作で進むズーム量は常に「1ステップ」固定
+            // 所要時間は常に ZOOM_DURATION_MS で一定
+            const zoomIn = e.deltaY < 0;
+
             if (e.ctrlKey) {
                 // 一様ズーム
-                // 一回の操作で進むズーム量は常に「1ステップ」固定
-                // 所要時間は常に ZOOM_DURATION_MS で一定
-                const zoomIn = e.deltaX < 0 || e.deltaY < 0;
                 animateZoomByTime(ZOOM_DURATION_MS, ZOOM_DIVISIONS_WHEEL, (divs) => {
                     const next = renderer.zoomUniform(store.state.renderCtx, mouseX, mouseY, zoomIn, divs);
+                    store.trigger(ACTION.UPDATE_RENDERER_CONTEXT, next);
+                });
+            } else if (e.shiftKey) {
+                // 水平ズーム
+                animateZoomByTime(ZOOM_DURATION_MS, ZOOM_DIVISIONS_WHEEL, (divs) => {
+                    const next = renderer.zoomHorizontal(store.state.renderCtx, mouseX, mouseY, zoomIn, divs);
                     store.trigger(ACTION.UPDATE_RENDERER_CONTEXT, next);
                 });
             } else {

--- a/src/ui_parts.tsx
+++ b/src/ui_parts.tsx
@@ -212,6 +212,7 @@ const HelpDialog = (props: { store: Store }) => {
                         <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
                             <li style={liStyle}><kbd style={kbdStyle}>Drag with left button</kbd><span>Pan.</span></li>
                             <li style={liStyle}><kbd style={kbdStyle}>Drag with right button</kbd><span>Pinch.</span></li>
+                            <li style={liStyle}><kbd style={kbdStyle}>Shift + mouse wheel</kbd><span>Zoom horizontal only.</span></li>
                             <li style={liStyle}><kbd style={kbdStyle}>Ctrl/⌘ + mouse wheel</kbd><span>Zoom in/out.</span></li>
                             <li style={liStyle}><kbd style={kbdStyle}>Ctrl/⌘ + up/down</kbd><span>Zoom vertical only.</span></li>
                             <li style={liStyle}><kbd style={kbdStyle}>Ctrl/⌘ + left/right</kbd><span>Zoom horizontal only.</span></li>


### PR DESCRIPTION
It turned out that horizontal scroll with mouse wheel is still useful for traditional mice which require more physical movement for dragging than for operating with wheels.