### PR TITLE
fix: include only files in src for TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,5 @@
         "lib": ["ES2020", "DOM"],
         "moduleResolution": "node"  // react-bootstrap で必要
     },
-    "exclude": [
-      "node_modules"
-    ]
+    "include": ["src"]
 }


### PR DESCRIPTION
Otherwise ts-loader enumerates the "work" directory and takes forever if it is huge and/or slow.