### PR TITLE
chore: explicitly specify key in LogOverlay

### DIFF
--- a/src/ui_parts.tsx
+++ b/src/ui_parts.tsx
@@ -426,8 +426,8 @@ const LogOverlay: React.FC<Props> = ({ store, width = 420, height = 120 }) => {
                     paddingRight: 48 // 右上アイコン分の余白
                 }}
             >
-                {logs.map(l => (
-                    <div>{l}</div>
+                {logs.map((l, index) => (
+                    <div key={index}>{l}</div>
                 ))}
             </div>
         </div>


### PR DESCRIPTION
React emits a warning if a key are missing in an array and falls back to the index.

It is fine to use the index in this case because the index of a particular element never changes, so explicitly state that by specifying indices as keys and suppress the warnings.